### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Raftel
 --
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5658bcc4be7d810100d8509e&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/5658bcc4be7d810100d8509e/build/latest)
 
 Raftel is iOS app to browse, read, and collect manga. It is rejected by the App Store because it's too simple and no interactivity. Which is bullshit because then apps like Medium should be rejected.
 


### PR DESCRIPTION
We really like Raftel and wanted to offer you a free continuous integration system [(buddybuild)](http://buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/5658bcc4be7d810100d8509e/build/latest) are the builds we've completed for Raftel so far.

![screen shot 2015-11-27 at 5 09 09 pm](https://cloud.githubusercontent.com/assets/13876667/11449437/da96244c-9529-11e5-8367-41972cee0c3e.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.